### PR TITLE
Adding a matrix to circle config so that tests for python versions in future can be added easily

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ variables:
 
 jobs:
 
-  test-py310:
+  test:
     parameters:
       python-version:
         type: string
@@ -182,13 +182,13 @@ workflows:
   version: 2.1
   test:
     jobs:
-      - test-py310:
+      - test:
           matrix:
             parameters:
               python-version: ["3.8", "3.9", "3.10"]
       - test-deploy-pypi:
           requires:
-            - test-py310
+            - test
           filters:
             branches:
               only:
@@ -196,7 +196,7 @@ workflows:
                 - add-more-python-versions             
       - productive-deploy-pypi:
           requires:
-            - test-py310
+            - test
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ variables:
   run_coveralls: &run_coveralls
     run:
       name: run coveralls
-      command: 
+      command: |
         source activate kipoi-dev
         coveralls || true
   store_test_results: &store_test_results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,7 +193,6 @@ workflows:
             branches:
               only:
                 - add-pypi-deployment   
-                - add-more-python-versions             
       - productive-deploy-pypi:
           requires:
             - test
@@ -201,4 +200,3 @@ workflows:
             branches:
               only:
                 - master
-                - add-more-python-versions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 variables:
   update_conda: &update_conda
@@ -12,7 +12,7 @@ variables:
   create_conda_env: &create_conda_env
     run:
       name: create conda env
-      command: conda create -n kipoi-dev python=3.10
+      command: conda create -n kipoi-dev python=<< parameters.python-version >>
   install_kipoi_utils: &install_kipoi_utils
     run:
       name: Install Kipoi Utils
@@ -89,10 +89,12 @@ variables:
         echo -e "username: $PYPI_USERNAME" >> ~/.pypirc
         echo -e "password: $PYPI_PASSWORD" >> ~/.pypirc
 
-
 jobs:
 
   test-py310:
+    parameters:
+      python-version:
+        type: string
     docker:
       - image: continuumio/miniconda3:latest
     working_directory: ~/repo
@@ -109,6 +111,10 @@ jobs:
       - *store_test_results
       - *store_test_artifacts  
   test-deploy-pypi:
+    parameters:
+      python-version:
+        type: string
+        default: "3.9"
     docker:
       - image: continuumio/miniconda3:latest
     working_directory: ~/repo
@@ -137,6 +143,10 @@ jobs:
             python -m pip install --user --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple kipoi_conda --verbose
             python -c "import kipoi_conda; print(kipoi_conda.__version__)"    
   productive-deploy-pypi:
+    parameters:
+      python-version:
+        type: string
+        default: "3.9"
     docker:
       - image: continuumio/miniconda3:latest
     working_directory: ~/repo
@@ -169,20 +179,20 @@ jobs:
 
 
 workflows:
-  version: 2
+  version: 2.1
   test:
     jobs:
-      - test-py310  
-  test-n-deploy:
-    jobs:
-      - test-py310
+      - test-py310:
+          matrix:
+            parameters:
+              python-version: ["3.8", "3.9", "3.10"]
       - test-deploy-pypi:
           requires:
             - test-py310
           filters:
             branches:
               only:
-                - add-pypi-deployment
+                - add-pypi-deployment                
       - productive-deploy-pypi:
           requires:
             - test-py310

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,8 @@ workflows:
           filters:
             branches:
               only:
-                - add-pypi-deployment                
+                - add-pypi-deployment   
+                - add-more-python-versions             
       - productive-deploy-pypi:
           requires:
             - test-py310
@@ -200,3 +201,4 @@ workflows:
             branches:
               only:
                 - master
+                - add-more-python-versions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,7 +185,7 @@ workflows:
       - test:
           matrix:
             parameters:
-              python-version: ["3.8", "3.9", "3.10"]
+              python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
       - test-deploy-pypi:
           requires:
             - test


### PR DESCRIPTION
Just add/remove version number [here](url)
Also fixed errors with coverall.io. The steps are as follows - 
1. Go to coveralls.io and create an account.
2. Use `ADD REPOS` from menu to add your choice of repo
3. Go back to REPOS and access your chosen repo's settings
4. Copy `REPO TOKEN`
5. Go to the CircleCI and the project settings of the repo in question
6. Add the copied token as an environment variable named `COVERALLS_REPO_TOKEN`