### PR TITLE
Add logging option for `get_envs()`

### DIFF
--- a/kipoi_conda/utils.py
+++ b/kipoi_conda/utils.py
@@ -172,13 +172,15 @@ def remove_env(env_name, dry_run=False):
     return _call_conda(cmd_list, use_stdout=True, dry_run=dry_run)
 
 
-def get_envs():
+def get_envs(is_logging = False):
     """
     Return all of the (named) environment (this does not include the root
     environment), as a list of absolute path to their prefixes.
     """
     json_str = check_output(["conda", "info", "--json"]).decode()
+    logger.info("conda info --json: " + json_str)
     info = json.loads(json_str)
+    logger.info("conda info --json: " + str(info))
     return info['envs']
 
 


### PR DESCRIPTION
This is to provide further info for [failing tests](https://app.circleci.com/pipelines/github/kipoi/models/2184/workflows/73b46646-03ea-48b4-9968-bd0cc857811a/jobs/20746) 